### PR TITLE
qc-21: Add rule for class names containing acronyms

### DIFF
--- a/src/javascript.md
+++ b/src/javascript.md
@@ -63,7 +63,7 @@
 
 ### Styles
 
-- **B8**. The layout of the blocks on the page is made by `flex` and `grid`.
+- **B8**. The layout of the blocks on the page is made by `flex` and/or `grid`.
 
 - <details>
     <summary>

--- a/src/javascript.md
+++ b/src/javascript.md
@@ -767,7 +767,7 @@
 
 - <details>
     <summary>
-      <b>B34.</b> There are no files, modules and parts of code that aren't used in the project code, including commented code pats.
+      <b>B34.</b> There are no files, modules and parts of code that are not used in the project code, including commented code pats.
     </summary>
     <p>
 
@@ -1011,11 +1011,11 @@
     </p>
   </details>
 
-- **A3.** Abstract classes or interfaces should have generic names and don’t contain implementation details.
+- **A3.** Abstract classes or interfaces should have generic names and do not contain implementation details.
 
 - <details>
     <summary>
-      <b>A4.</b> The names of methods/functions and properties/variables of objects don't contain the names of object/module.
+      <b>A4.</b> The names of methods/functions and properties/variables of objects do not contain the names of object/module.
     </summary>
     <p>
 

--- a/src/javascript.md
+++ b/src/javascript.md
@@ -419,6 +419,20 @@
   ```
 
     </p>
+
+    <p>In cases when there is one or more acronyms in the enum name, it should have the first acronym in uppercase whereas all others be handled as a regular word (only the first letter is capitalized)</p>
+
+    Bad: 
+
+    ```typescript
+      class XmlHttpRequest {}
+    ```
+
+    Good:
+
+    ```typescript
+      class XMLHttpRequest {}
+    ```
   </details>
 
 - <details>
@@ -464,6 +478,20 @@
   ```
 
     </p>
+
+    <p>In cases when there is one or more acronyms in the enum name, it should have the first acronym in uppercase whereas all others be handled as a regular word (only the first letter is capitalized)</p>
+
+    Bad: 
+
+    ```typescript
+      const HttpStatusCode {}
+    ```
+
+    Good:
+
+    ```typescript
+      const HTTPStatusCode {}
+    ```
   </details>
 
 - <details>

--- a/src/javascript.md
+++ b/src/javascript.md
@@ -422,17 +422,18 @@
 
     <p>In cases when there is one or more acronyms in the enum name, it should have the first acronym in uppercase whereas all others be handled as a regular word (only the first letter is capitalized)</p>
 
-    Bad: 
+  Bad:
 
-    ```typescript
-      class XmlHttpRequest {}
-    ```
+  ```typescript
+  class XmlHttpRequest {}
+  ```
 
-    Good:
+  Good:
 
-    ```typescript
-      class XMLHttpRequest {}
-    ```
+  ```typescript
+  class XMLHttpRequest {}
+  ```
+
   </details>
 
 - <details>
@@ -481,17 +482,18 @@
 
     <p>In cases when there is one or more acronyms in the enum name, it should have the first acronym in uppercase whereas all others be handled as a regular word (only the first letter is capitalized)</p>
 
-    Bad: 
+  Bad:
 
-    ```typescript
-      const HttpStatusCode {}
-    ```
+  ```typescript
+  const HttpStatusCode = {};
+  ```
 
-    Good:
+  Good:
 
-    ```typescript
-      const HTTPStatusCode {}
-    ```
+  ```typescript
+  const HTTPStatusCode = {};
+  ```
+
   </details>
 
 - <details>
@@ -519,6 +521,7 @@
   Exceptions:
 
   Framework/library files that cannot work with another case.
+
     </p>
   </details>
 
@@ -1008,7 +1011,7 @@
     </p>
   </details>
 
-- **A3.** Abstract classes or interfaces should have generic names and don't contain implementation details.
+- **A3.** Abstract classes or interfaces should have generic names and don’t contain implementation details.
 
 - <details>
     <summary>


### PR DESCRIPTION
The first acronym in the name must be capitalized, all others must have only the first letter capitalized.
Examples: `JSON`, `XMLHttpRequest`, `HTMLMediaElement` etc.

closes: https://github.com/BinaryStudioAcademy/quality-criteria/issues/7