### PR TITLE
JS: Fix incorrect rule number

### DIFF
--- a/src/javascript.md
+++ b/src/javascript.md
@@ -531,7 +531,7 @@
 
 - <details>
     <summary>
-      <b>B27.</b> The code matches the style of the project.
+      <b>B26.</b> The code matches the style of the project.
     </summary>
     <p>
 


### PR DESCRIPTION
Rule B26 was missing in JavaScript and B27 was repeated twice.